### PR TITLE
Feature Flag Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ cocoon = "0.4.1"
 lazy_static = "1.4.0"
 serde_json = "1.0.41"
 serde = { version = "1.0", features = ["derive"] }
+
+
+[features]
+default = []
+fuzzy-select = ["dialoguer/fuzzy-select"]


### PR DESCRIPTION
Added fuzzy-select under [features] in Cargo.toml so that #[cfg(feature = "fuzzy-select")] compiles without warnings.
<img width="1920" height="1080" alt="Screenshot from 2025-09-14 10-28-07" src="https://github.com/user-attachments/assets/c5596ef8-5a07-4d61-9b96-0dd37019018f" />
